### PR TITLE
Oprava fake war

### DIFF
--- a/aliance.htm
+++ b/aliance.htm
@@ -274,30 +274,24 @@ z následujících:</p>
 <p>&nbsp;</p>
   <hr>
   <p>&nbsp;</p>
- <a NAME="FW"></a> 
+ <a name="FW"></a>
 <h3><b>10.4.4 </b>Fake War (fiktivní válka):</h3>
-  <p><strong>1)</strong> <em>(ruší systém) </em>Fake war může vzniknout, 
-  pokud válka trvá déle než 36h, za posledních 24h nebylo dohromady z obou stran 
-  alespoň 5 úspěšných útoků a zároveň za celou válku padlo méně než 5*[aktuální počet členů vyhlašující aliance] úspěšných útoků 
-  a zároveň méně než 1*[aktuální počet členů vyhlašující aliance] úspěšných normálních útoků.
-  
-  <p></p>
-  <p><strong>2) </strong><em>(sami si rušíte válku) </em>Fake war může vzniknout 
-  pokud, padlo méně než 5*[aktuální počet členů vyhlašující aliance] úspěšných útoků a zároveň méně než 1*[aktuální počet členů vyhlašující aliance] úspěšných normálních útoků 
-  a válku jste si zrušili sami nebo ji zrušil soupeř po 3 dnech.<br>
-  </p>
-  <p></p>
-<p>Fake war se píší k alianci a jsou vidět v menu <span class="menu">Konflikty - Fake war</span>. První fake war je v normě, 2. fake war znamená 
+  <p>Za fiktivní válku je považována taková válka, ve které nepadl odpovídající počet vojenských útoků ze strany <strong>vyhlašující aliance</strong>. K odvrácení fiktivní války je nutné, aby vyhlašující strana splnila v době ukončení války <strong>obě následující podmínky</strong>:</p>
+  <blockquote>
+    <p><strong>1)</strong> Počet všech úspěšných <a href="valky.htm#Vou">útoků</a> (bez raket a rozvědky) musí být vyšší nebo roven <strong>5*[aktuální počet členů vyhlašující aliance]</strong>.</p>
+    <p><strong>2)</strong> Počet všech úspěšných <a href="valky.htm#UNorm">normálních</a> útoků musí být vyšší nebo roven <strong>1*[aktuální počet členů vyhlašující aliance]</strong>.</p>
+  </blockquote>
+
+  <p>Fake war se píší k alianci a jsou vidět v menu <span class="menu">Konflikty - Fake war</span>. První fake war je v normě, 2. fake war znamená
 ztrátu 2% zkušeností (<a href="valky.htm#Vxp">armády</a>, <a href="statistiky.htm#H3">země</a> i <a href="valky.htm#Gen">generálů</a>), 3. fake war znamená ztrátu 4%, 4. fake war znamená ztrátu 6%...</p>
-<p>&nbsp;</p>
-<p>Pokud se stane, že nepřátelská aliance ve chvíli ukončení války má alespoň <strong>o 50%  <a href="statistiky.htm#H1">prestiže</a> méně</strong> (např. vlivem odchodů z aliance) než ve chvíli vyhlášení, <strong>nebude</strong> tato válka fake.</p>
+
+  <p>Pokud se stane, že nepřátelská aliance ve chvíli ukončení války má alespoň <strong>o 50% <a href="statistiky.htm#H1">prestiže</a> méně</strong> (např. vlivem odchodů z aliance) než ve chvíli vyhlášení, <strong>nebude</strong> tato válka fake.</p>
+
+  <p>Počet útoků se počítá ve chvíli <strong>rušení války</strong>, takže pokud odešli/přišli členové, vyhodnocuje se podle aktuálního stavu.</p>
+
 <h3><b>10.4.5 </b>Neaktivní válka:</h3>
-  <p>Pokud je limit 5*[aktuální počet členů vyhlašující aliance] úspěšných útoků a zároveň 1*[aktuální počet členů vyhlašující aliance] úspěšných normálních útoků ze strany 
-  vyhlašující aliance splněn a za posledních 24h nepadlo dohromady z obou stran alespoň 5 úspěšných útoků je válka označená za neaktivní. Za neaktivní válku <strong>není 
-  žadný postih. </strong> Válka je prohlášena za neaktivní nejdříve 36h po vyhlášení.</p>
-  <p>&nbsp;</p>
-  
-  <p><strong>Počet útoků se počítá ve chvíli rušení války, takže pokud odešli/přišli členové, vyhodnocuje se podle aktuálního stavu.</strong></p>
+  <p>Pokud válka trvá <strong>déle než 36 hodin</strong> a za <strong>posledních 24h nepadlo dohromady z obou stran alespoň 5 úspěšných útoků</strong> (včetně raket), je válka označená za neaktivní a zrušena systémem. Za neaktivní válku <strong>není
+  žadný postih.</strong></p>
   <p>&nbsp;</p>
   <hr>
 </blockquote>

--- a/aliance.htm
+++ b/aliance.htm
@@ -289,6 +289,7 @@ ztrátu 2% zkušeností (<a href="valky.htm#Vxp">armády</a>, <a href="statistik
 
   <p>Počet útoků se počítá ve chvíli <strong>rušení války</strong>, takže pokud odešli/přišli členové, vyhodnocuje se podle aktuálního stavu.</p>
 
+<a name="neaktivni_valka"></a>
 <h3><b>10.4.5 </b>Neaktivní válka:</h3>
   <p>Pokud válka trvá <strong>déle než 36 hodin</strong> a za <strong>posledních 24h nepadlo dohromady z obou stran alespoň 5 úspěšných útoků</strong> (včetně raket), je válka označená za neaktivní a zrušena systémem. Za neaktivní válku <strong>není
   žadný postih.</strong></p>

--- a/faq.htm
+++ b/faq.htm
@@ -92,10 +92,10 @@ Váš problém vyřešen. Bonusy se ale srovnají až po kliknutí do pracovny.
 <p align="right"><a href="#faq">nahoru</a></p>
 <p><strong>Čau, hele já jsem vyhlásil válku a nám odešli lidi z ali. Bylo nás 5 
 a teď jsme 3. Kolik musíme dát útoků, aby to nebyla fake?</strong></p>
-Hodnotí se to podle počtu členů v alianci při rušení války, tzn. pro Váš případ to je 
-snížení z původních 35 úspěšných útoků na 21 (aby nebyla fake je třeba dát 
-7*[aktuální počet členů vyhlašující aliance] úspěšných útoků a zároveň 1*[aktuální počet členů vyhlašující aliance] úspěšných normálních útoků).
-Fake War <strong>nevznike</strong> pokud potřebný počet útoků splní kterákoliv ze stran, nicméně početní podmínka je vždy závislá na počtu vyhlašující aliance.
+<a href="aliance.htm#FW">Fake war</a> se hodnotí podle počtu členů v alianci při rušení války, tzn. pro váš případ to je
+snížení z původních 25 úspěšných útoků na 15 a z původních 5 úspěšných normálních útoků na 3 (aby nebyla fake je třeba dát
+5*[aktuální počet členů vyhlašující aliance] úspěšných útoků a zároveň 1*[aktuální počet členů vyhlašující aliance] úspěšných normálních útoků).
+Útoky k odvrácení fake war musí vždy splnit <strong>vyhlašující aliance</strong>.
 <p align="right"><a href="#faq">nahoru</a></p>
   <br>
   <hr>

--- a/faq.htm
+++ b/faq.htm
@@ -292,26 +292,24 @@ Když válka byla vyhlášena Vám, tak po 3 dnech se dá zrušit i z Vaší str
 
 <p><strong>Jak vzniká fake war?</strong></p>
 
-  <p><strong>1)</strong> <em>(ruší systém) - </em>Fake war může vzniknout, 
+  <p><strong>1)</strong> <em>(ruší systém) - </em><a href="aliance.htm#FW">Fake war</a> může vzniknout,
   pokud válka trvá déle než 36h, za posledních 24h nebylo dohromady z obou stran 
-  alespoň 5 úspěšných útoků a zároveň za celou válku padlo méně než 7*[aktuální počet členů vyhlašující aliance] úspěšných útoků 
-  a zároveň méně než 1*[aktuální počet členů vyhlašující aliance] úspěšných normálních útoků.
+  alespoň 5 úspěšných útoků (počítají se i rakety) a zároveň za celou válku vyhlašující aliance učinila méně než 5*[aktuální počet členů vyhlašující aliance] úspěšných útoků
+  a nebo méně než 1*[aktuální počet členů vyhlašující aliance] úspěšných normálních útoků.
   </p>
   <p>
-<strong>2) </strong><em>(sami si rušíte válku) - </em>Fake war může vzniknout 
-  pokud, padlo méně než 7*[aktuální počet členů vyhlašující aliance] úspěšných útoků a zároveň méně než 1*[aktuální počet členů vyhlašující aliance] úspěšných normálních útoků 
-  a válku jste si zrušili sami nebo ji zrušil soupeř po 3 dnech.
+<strong>2) </strong><em>(sami si rušíte válku) - </em><a href="aliance.htm#FW">Fake war</a> může vzniknout
+  pokud vyhlašující aliance učilina méně než 5*[aktuální počet členů vyhlašující aliance] úspěšných útoků a nebo méně než 1*[aktuální počet členů vyhlašující aliance] úspěšných normálních útoků
+  a válka je zrušena vyhlašující stranou (nejdříve za 24 hodin od vyhlášení) nebo napadenou (nejdříve za 72 hodin).
   </p>
   <p></p>
-  <p>Fake War <strong>nevznikne</strong>, pokud potřebný počet útoků splní kterákoliv ze stran, nicméně početní podmínka je vždy závislá na počtu členů vyhlašující aliance.</p>
-  <p></p>
   <p>
-<strong>3)</strong> Neaktivní válka (v obou případech) - Pokud je limit 7*[aktuální počet členů vyhlašující aliance] úspěšných útoků a zároveň 1*[aktuální počet členů vyhlašující aliance] úspěšných normálních útoků ze strany 
+<strong>3)</strong> <a href="aliance.htm#neaktivni_valka">Neaktivní válka</a> (v obou případech) - Pokud je limit 5*[aktuální počet členů vyhlašující aliance] úspěšných útoků a zároveň 1*[aktuální počet členů vyhlašující aliance] úspěšných normálních útoků ze strany
   vyhlašující aliance splněn a za posledních 24h nepadlo dohromady z obou stran alespoň 5 úspěšných útoků, je válka označená za neaktivní. Za neaktivní válku <strong>není 
   žadný postih. </strong> Válka je prohlášena za neaktivní nejdříve 36h po vyhlášení.
    </p>
 <br>
-<strong>Pokud aliance válku pouze pojistí není nutné plnit počet útoků. Ty musí splnit pouze vyhlašující aliance.</strong>
+<strong>Pokud aliance válku pouze pojistí, není nutné plnit počet útoků. Ty musí splnit pouze vyhlašující aliance.</strong>
   <p align="right"><a href="#faq">nahoru</a></p>
   <p>&nbsp;</p>
   <hr>

--- a/gwg/aliance.htm
+++ b/gwg/aliance.htm
@@ -106,7 +106,7 @@ z následujících:</p>
 <p>&nbsp;</p>
   <hr>
   <p>&nbsp;</p>
- <a NAME="FW"></a> 
+ <a NAME="FW"></a>
 <h3><b>10.3.4</b> Fake War (fiktivní válka):</h3>
   <p>Fake war může vzniknout, 
   pokud válka trvá déle než 36h, za posledních 24h nebylo dohromady z obou stran

--- a/nabidkaleft.htm
+++ b/nabidkaleft.htm
@@ -86,7 +86,7 @@ function cls2(co){
     <td height=29 align="center" bgcolor="#8899cc"><font size=3 color="white"><b>Webgame.cz</b></font></td>
   </tr>
       <tr>
-        <td align="center" bgcolor="#8899cc"><font style="font-size:12px";>Aktualizace 29. 05. 2020</font>
+        <td align="center" bgcolor="#8899cc"><font style="font-size:12px";>Aktualizace 31. 05. 2020</font>
 <br>
 <font  class=nadpis> <a href="wghelp.zip"><i>Stáhnout (cca 2,5 MB)</i></a>
 </font></td></tr>

--- a/ufo.htm
+++ b/ufo.htm
@@ -58,7 +58,7 @@
 <p>&nbsp;</p>
 <b>Pokroky:</b><ul>
          <li>Mimozemský superpočítač (M) - Přidá +15% k <a href="techno.htm#TEf">maximálnímu efektu</a> hospodářských technologií a +15% k produkci technologií.</li>
-         <li>Výroba bojových cyborgů (M) - Pomocí tohoto pokroku se Vám přemění každé kolo 500 <a href="valky.htm#Voj">vojáků</a> a 500 MWh <a href="zbozi.htm#Ene">energie</a> na 500 <a href="valky.htm#Mech">mechů</a>. Produkce cyborgů je zastavena, pokud  máte v zemi méně než 5000 vojáků a 5000 energie.</li>
+         <li>Výroba bojových cyborgů (M) - Pomocí tohoto pokroku se Vám přemění každé kolo 500 <a href="valky.htm#Voj">vojáků</a> a 500 MWh <a href="zbozi.htm#Ene">energie</a> na 500 <a href="valky.htm#Mech">mechů</a>. Produkce cyborgů je zastavena, pokud  máte v zemi méně než 5000 vojáků a 5000 energie.</li><a name="cyborgove"></a>
          <li>Plazmové zbraně (M) - Maximální efekt síly zbraní se zvýší ze 140% na 150%. Zároveň získáte +25% efekt vojenských základen za <a href="techno.htm#Tchsi">sílu zbraní</a>. Provoz jednotek spotřebovává hodně energie (na 1M prestiže v armádě např. 2000MWh/kolo).</li>
          <li>Chytré miny (M) - Zvýší ztráty nepřátelských útočících tanků, mechů a vojáků v obraně o 25%.</li>
        </ul>

--- a/valky.htm
+++ b/valky.htm
@@ -733,8 +733,8 @@ Za 14. hodnost (Nepřítel populace) je +10% síla armády </td>
       míru, a proto snižují zkušenost méně, než cizí koupené jednotky.</p>
         
         <p>Zkušenosti také ztratíte při odchodu z <a href="aliance.htm#Al">aliance</a> a sice přesně 1/3 Vašich <a href="#Vxp">zkušeností armády</a>.</p>
-        <p>Zkušenosti ztratíte také za systémem zrušené Fake war ( 2. FW znamená ztrátu 2% zkušeností armády, země i generálů, 3. 4%, 4. 6%...)</p>
-        <p class="inf">Posláním jednotek hospodářskou pomocí neklesají zkušenosti armády. Vojáci za svatou válku a cyborgové neubírají zkušenosti armády.</p>
+        <p>Zkušenosti ztratíte také za systémem zrušené <a href="aliance.htm#FW">Fake war</a> (2. fake war znamená ztrátu 2% zkušeností armády, země i generálů, 3. 4%, 4. 6% ...)</p>
+        <p class="inf">Posláním jednotek hospodářskou pomocí neklesají zkušenosti armády. Vojáci za <a href="techno.htm#TPs">Svatou válku</a> a <a href="ufo.htm#cyborgove">cyborgové</a> neubírají zkušenosti armády.</p>
         <p>&nbsp;    </p>
         <hr>
         <p><a name=Gen></a></p>


### PR DESCRIPTION
Přidal jsem lepší formulaci potřebných podmínek, kdy si hráč stěžoval na špatnou formulaci věty s **a zároveň**. Odstranil jsem i rozdělení fake war na rušena systémem a hráčem. Fake war je prostě jedna, rušení war systémem je pak samostatná záležitost neaktivní války.

:pray: